### PR TITLE
query subsequent/preceeding journeys by ref

### DIFF
--- a/docs/journeys.md
+++ b/docs/journeys.md
@@ -249,7 +249,7 @@ Some [profiles](../p) are able to parse the ticket information, if returned by t
 
 If a journey leg has been cancelled, a `cancelled: true` will be added. Also, `departure`/`departureDelay`/`departurePlatform` and `arrival`/`arrivalDelay`/`arrivalPlatform` will be `null`.
 
-To get more journeys earlier/later than the current set of results, use `journey.earlierRef`/`journey.laterRef` as follows:
+To get more journeys earlier/later than the current set of results, pass `journeys.earlierRef`/`journeys.laterRef` into `opt.earlierThan`/`opt.laterThan`. For example, query *later* journeys as follows:
 
 ```js
 const hbf = '900000003201'

--- a/docs/journeys.md
+++ b/docs/journeys.md
@@ -41,6 +41,8 @@ With `opt`, you can override the default options, which look like this:
 ```js
 {
 	when: new Date(),
+	earlierThan: null, // ref to get journeys earlier than the last query
+	laterThan: null, // ref to get journeys later than the last query
 	results: 5, // how many journeys?
 	via: null, // let journeys pass this station
 	passedStations: false, // return stations on the way?
@@ -85,123 +87,127 @@ client.journeys('900000003201', '900000100008', {
 The response may look like this:
 
 ```js
-[ {
-	legs: [ {
-		id: '1|31041|35|86|17122017',
+[
+	{
+		legs: [ {
+			id: '1|31041|35|86|17122017',
+			origin: {
+				type: 'station',
+				id: '900000003201',
+				name: 'S+U Berlin Hauptbahnhof',
+				location: {
+					type: 'location',
+					latitude: 52.52585,
+					longitude: 13.368928
+				},
+				products: {
+					suburban: true,
+					subway: true,
+					tram: true,
+					bus: true,
+					ferry: false,
+					express: true,
+					regional: true
+				}
+			},
+			departure: '2017-12-17T19:07:00.000+01:00',
+			departurePlatform: '16',
+			destination: {
+				type: 'station',
+				id: '900000024101',
+				name: 'S Charlottenburg',
+				location: {
+					type: 'location',
+					latitude: 52.504806,
+					longitude: 13.303846
+				},
+				products: {
+					suburban: true,
+					subway: false,
+					tram: false,
+					bus: true,
+					ferry: false,
+					express: false,
+					regional: true
+				}
+			},
+			arrival: '2017-12-17T19:47:00.000+01:00',
+			arrivalPlatform: '8',
+			arrivalDelay: 30,
+			line: {
+				type: 'line',
+				id: '16845',
+				name: 'S7',
+				public: true,
+				mode: 'train',
+				product: 'suburban',
+				symbol: 'S',
+				nr: 7,
+				metro: false,
+				express: false,
+				night: false,
+				productCode: 0,
+				operator: {
+					type: 'operator',
+					id: 's-bahn-berlin-gmbh',
+					name: 'S-Bahn Berlin GmbH'
+				}
+			},
+			direction: 'S Potsdam Hauptbahnhof',
+			passed: [ {
+				station: {
+					type: 'station',
+					id: '900000003201',
+					name: 'S+U Berlin Hauptbahnhof',
+					location: { /* … */ },
+					products: { /* … */ }
+				},
+				arrival: null,
+				departure: null,
+				cancelled: true
+			}, {
+				station: {
+					type: 'station',
+					id: '900000003102',
+					name: 'S Bellevue',
+					location: { /* … */ },
+					products: { /* … */ }
+				},
+				arrival: '2017-12-17T19:09:00.000+01:00',
+				departure: '2017-12-17T19:09:00.000+01:00'
+			}, /* … */ {
+				station: {
+					type: 'station',
+					id: '900000024101',
+					name: 'S Charlottenburg',
+					location: { /* … */ },
+					products: { /* … */ }
+				},
+				arrival: '2017-12-17T19:17:00.000+01:00',
+				departure: '2017-12-17T19:17:00.000+01:00'
+			} ]
+		} ],
 		origin: {
 			type: 'station',
 			id: '900000003201',
 			name: 'S+U Berlin Hauptbahnhof',
-			location: {
-				type: 'location',
-				latitude: 52.52585,
-				longitude: 13.368928
-			},
-			products: {
-				suburban: true,
-				subway: true,
-				tram: true,
-				bus: true,
-				ferry: false,
-				express: true,
-				regional: true
-			}
+			location: { /* … */ },
+			products: { /* … */ }
 		},
 		departure: '2017-12-17T19:07:00.000+01:00',
-		departurePlatform: '16',
 		destination: {
 			type: 'station',
 			id: '900000024101',
 			name: 'S Charlottenburg',
-			location: {
-				type: 'location',
-				latitude: 52.504806,
-				longitude: 13.303846
-			},
-			products: {
-				suburban: true,
-				subway: false,
-				tram: false,
-				bus: true,
-				ferry: false,
-				express: false,
-				regional: true
-			}
+			location: { /* … */ },
+			products: { /* … */ }
 		},
 		arrival: '2017-12-17T19:47:00.000+01:00',
-		arrivalPlatform: '8',
-		arrivalDelay: 30,
-		line: {
-			type: 'line',
-			id: '16845',
-			name: 'S7',
-			public: true,
-			mode: 'train',
-			product: 'suburban',
-			symbol: 'S',
-			nr: 7,
-			metro: false,
-			express: false,
-			night: false,
-			productCode: 0,
-			operator: {
-				type: 'operator',
-				id: 's-bahn-berlin-gmbh',
-				name: 'S-Bahn Berlin GmbH'
-			}
-		},
-		direction: 'S Potsdam Hauptbahnhof',
-		passed: [ {
-			station: {
-				type: 'station',
-				id: '900000003201',
-				name: 'S+U Berlin Hauptbahnhof',
-				location: { /* … */ },
-				products: { /* … */ }
-			},
-			arrival: null,
-			departure: null,
-			cancelled: true
-		}, {
-			station: {
-				type: 'station',
-				id: '900000003102',
-				name: 'S Bellevue',
-				location: { /* … */ },
-				products: { /* … */ }
-			},
-			arrival: '2017-12-17T19:09:00.000+01:00',
-			departure: '2017-12-17T19:09:00.000+01:00'
-		}, /* … */ {
-			station: {
-				type: 'station',
-				id: '900000024101',
-				name: 'S Charlottenburg',
-				location: { /* … */ },
-				products: { /* … */ }
-			},
-			arrival: '2017-12-17T19:17:00.000+01:00',
-			departure: '2017-12-17T19:17:00.000+01:00'
-		} ]
-	} ],
-	origin: {
-		type: 'station',
-		id: '900000003201',
-		name: 'S+U Berlin Hauptbahnhof',
-		location: { /* … */ },
-		products: { /* … */ }
+		arrivalDelay: 30
 	},
-	departure: '2017-12-17T19:07:00.000+01:00',
-	destination: {
-		type: 'station',
-		id: '900000024101',
-		name: 'S Charlottenburg',
-		location: { /* … */ },
-		products: { /* … */ }
-	},
-	arrival: '2017-12-17T19:47:00.000+01:00',
-	arrivalDelay: 30
-} ]
+	earlierRef: '…', // use with the `earlierThan` option
+	laterRef: '…' // use with the `laterThan` option
+]
 ```
 
 Some [profiles](../p) are able to parse the ticket information, if returned by the API. For example, if you pass `tickets: true` with the [VBB profile](../p/vbb), each `journey` will have a tickets array that looks like this:
@@ -242,3 +248,31 @@ Some [profiles](../p) are able to parse the ticket information, if returned by t
 ```
 
 If a journey leg has been cancelled, a `cancelled: true` will be added. Also, `departure`/`departureDelay`/`departurePlatform` and `arrival`/`arrivalDelay`/`arrivalPlatform` will be `null`.
+
+To get more journeys earlier/later than the current set of results, use `journey.earlierRef`/`journey.laterRef` as follows:
+
+```js
+const hbf = '900000003201'
+const heinrichHeineStr = '900000100008'
+
+client.journeys(hbf, heinrichHeineStr)
+.then((journeys) => {
+	const lastJourney = journeys[journeys.length - 1]
+	console.log('departure of last journey', lastJourney.departure)
+
+	// get later journeys
+	return client.journeys(hbf, heinrichHeineStr, {
+		laterThan: journeys.laterRef
+	})
+})
+.then((laterourneys) => {
+	const firstJourney = laterourneys[laterourneys.length - 1]
+	console.log('departure of first (later) journey', firstJourney.departure)
+})
+.catch(console.error)
+```
+
+```
+departure of last journey 2017-12-17T19:07:00.000+01:00
+departure of first (later) journey 2017-12-17T19:19:00.000+01:00
+```

--- a/index.js
+++ b/index.js
@@ -132,8 +132,8 @@ const createClient = (profile, request = _request) => {
 			const parse = profile.parseJourney(profile, d.locations, d.lines, d.remarks)
 			const res = d.outConL.map(parse)
 
-			if (d.outCtxScrB) res.earlierJourneysRef = d.outCtxScrB
-			if (d.outCtxScrF) res.laterJourneysRef = d.outCtxScrF
+			if (d.outCtxScrB) res.earlierRef = d.outCtxScrB
+			if (d.outCtxScrF) res.laterRef = d.outCtxScrF
 			return res
 		})
 	}

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const defaultProfile = require('./lib/default-profile')
 const _request = require('./lib/request')
 
 const isObj = o => o !== null && 'object' === typeof o && !Array.isArray(o)
+const isNonEmptyString = str => 'string' === typeof str && str.length > 0
 
 const createClient = (profile, request = _request) => {
 	profile = Object.assign({}, defaultProfile, profile)
@@ -110,7 +111,7 @@ const createClient = (profile, request = _request) => {
 	}
 
 	const locations = (query, opt = {}) => {
-		if ('string' !== typeof query || !query) {
+		if (!isNonEmptyString(query)) {
 			throw new Error('query must be a non-empty string.')
 		}
 		opt = Object.assign({
@@ -204,10 +205,10 @@ const createClient = (profile, request = _request) => {
 	}
 
 	const journeyLeg = (ref, lineName, opt = {}) => {
-		if ('string' !== typeof ref || !ref) {
+		if (!isNonEmptyString(ref)) {
 			throw new Error('ref must be a non-empty string.')
 		}
-		if ('string' !== typeof lineName || !lineName) {
+		if (!isNonEmptyString(lineName)) {
 			throw new Error('lineName must be a non-empty string.')
 		}
 		opt = Object.assign({

--- a/index.js
+++ b/index.js
@@ -52,27 +52,27 @@ const createClient = (profile, request = _request) => {
 		from = profile.formatLocation(profile, from)
 		to = profile.formatLocation(profile, to)
 
-		if (('beforeJourneys' in opt) && ('afterJourneys' in opt)) {
-			throw new Error('opt.afterJourneys and opt.afterJourneys are mutually exclusive.')
+		if (('earlierThan' in opt) && ('laterThan' in opt)) {
+			throw new Error('opt.laterThan and opt.laterThan are mutually exclusive.')
 		}
 		let journeysRef = null
-		if ('beforeJourneys' in opt) {
-			if (!isNonEmptyString(opt.beforeJourneys)) {
-				throw new Error('opt.beforeJourneys must be a non-empty string.')
+		if ('earlierThan' in opt) {
+			if (!isNonEmptyString(opt.earlierThan)) {
+				throw new Error('opt.earlierThan must be a non-empty string.')
 			}
 			if ('when' in opt) {
-				throw new Error('opt.beforeJourneys and opt.when are mutually exclusive.')
+				throw new Error('opt.earlierThan and opt.when are mutually exclusive.')
 			}
-			journeysRef = opt.beforeJourneys
+			journeysRef = opt.earlierThan
 		}
-		if ('afterJourneys' in opt) {
-			if (!isNonEmptyString(opt.afterJourneys)) {
-				throw new Error('opt.afterJourneys must be a non-empty string.')
+		if ('laterThan' in opt) {
+			if (!isNonEmptyString(opt.laterThan)) {
+				throw new Error('opt.laterThan must be a non-empty string.')
 			}
 			if ('when' in opt) {
-				throw new Error('opt.afterJourneys and opt.when are mutually exclusive.')
+				throw new Error('opt.laterThan and opt.when are mutually exclusive.')
 			}
-			journeysRef = opt.afterJourneys
+			journeysRef = opt.laterThan
 		}
 
 		opt = Object.assign({

--- a/test/db.js
+++ b/test/db.js
@@ -243,6 +243,18 @@ test('earlier/later journeys, Jungfernheide -> München Hbf', co(function* (t) {
 	t.equal(typeof model.laterRef, 'string')
 	t.ok(model.laterRef)
 
+	// when and earlierThan/laterThan should be mutually exclusive
+	t.throws(() => {
+		client.journeys(jungfernh, münchenHbf, {
+			when, earlierThan: model.earlierRef
+		})
+	})
+	t.throws(() => {
+		client.journeys(jungfernh, münchenHbf, {
+			when, laterThan: model.laterRef
+		})
+	})
+
 	let earliestDep = Infinity, latestDep = -Infinity
 	for (let j of model) {
 		const dep = +new Date(j.departure)
@@ -253,7 +265,7 @@ test('earlier/later journeys, Jungfernheide -> München Hbf', co(function* (t) {
 	const earlier = yield client.journeys(jungfernh, münchenHbf, {
 		results: 3,
 		// todo: single journey ref?
-		beforeJourneys: model.earlierRef
+		earlierThan: model.earlierRef
 	})
 	for (let j of earlier) {
 		t.ok(new Date(j.departure) < earliestDep)
@@ -262,7 +274,7 @@ test('earlier/later journeys, Jungfernheide -> München Hbf', co(function* (t) {
 	const later = yield client.journeys(jungfernh, münchenHbf, {
 		results: 3,
 		// todo: single journey ref?
-		afterJourneys: model.laterRef
+		laterThan: model.laterRef
 	})
 	for (let j of later) {
 		t.ok(new Date(j.departure) > latestDep)

--- a/test/db.js
+++ b/test/db.js
@@ -238,10 +238,10 @@ test('earlier/later journeys, Jungfernheide -> München Hbf', co(function* (t) {
 		results: 3, when
 	})
 
-	t.equal(typeof model.earlierJourneysRef, 'string')
-	t.ok(model.earlierJourneysRef)
-	t.equal(typeof model.laterJourneysRef, 'string')
-	t.ok(model.laterJourneysRef)
+	t.equal(typeof model.earlierRef, 'string')
+	t.ok(model.earlierRef)
+	t.equal(typeof model.laterRef, 'string')
+	t.ok(model.laterRef)
 
 	let earliestDep = Infinity, latestDep = -Infinity
 	for (let j of model) {
@@ -253,7 +253,7 @@ test('earlier/later journeys, Jungfernheide -> München Hbf', co(function* (t) {
 	const earlier = yield client.journeys(jungfernh, münchenHbf, {
 		results: 3,
 		// todo: single journey ref?
-		beforeJourneys: model.earlierJourneysRef
+		beforeJourneys: model.earlierRef
 	})
 	for (let j of earlier) {
 		t.ok(new Date(j.departure) < earliestDep)
@@ -262,7 +262,7 @@ test('earlier/later journeys, Jungfernheide -> München Hbf', co(function* (t) {
 	const later = yield client.journeys(jungfernh, münchenHbf, {
 		results: 3,
 		// todo: single journey ref?
-		afterJourneys: model.laterJourneysRef
+		afterJourneys: model.laterRef
 	})
 	for (let j of later) {
 		t.ok(new Date(j.departure) > latestDep)

--- a/test/oebb.js
+++ b/test/oebb.js
@@ -284,6 +284,18 @@ test('earlier/later journeys, Salzburg Hbf -> Wien Westbahnhof', co(function* (t
 	t.equal(typeof model.laterRef, 'string')
 	t.ok(model.laterRef)
 
+	// when and earlierThan/laterThan should be mutually exclusive
+	t.throws(() => {
+		client.journeys(salzburgHbf, wienWestbahnhof, {
+			when, earlierThan: model.earlierRef
+		})
+	})
+	t.throws(() => {
+		client.journeys(salzburgHbf, wienWestbahnhof, {
+			when, laterThan: model.laterRef
+		})
+	})
+
 	let earliestDep = Infinity, latestDep = -Infinity
 	for (let j of model) {
 		const dep = +new Date(j.departure)
@@ -294,7 +306,7 @@ test('earlier/later journeys, Salzburg Hbf -> Wien Westbahnhof', co(function* (t
 	const earlier = yield client.journeys(salzburgHbf, wienWestbahnhof, {
 		results: 3,
 		// todo: single journey ref?
-		beforeJourneys: model.earlierRef
+		earlierThan: model.earlierRef
 	})
 	for (let j of earlier) {
 		t.ok(new Date(j.departure) < earliestDep)
@@ -303,7 +315,7 @@ test('earlier/later journeys, Salzburg Hbf -> Wien Westbahnhof', co(function* (t
 	const later = yield client.journeys(salzburgHbf, wienWestbahnhof, {
 		results: 3,
 		// todo: single journey ref?
-		afterJourneys: model.laterRef
+		laterThan: model.laterRef
 	})
 	for (let j of later) {
 		t.ok(new Date(j.departure) > latestDep)

--- a/test/oebb.js
+++ b/test/oebb.js
@@ -279,10 +279,10 @@ test('earlier/later journeys, Salzburg Hbf -> Wien Westbahnhof', co(function* (t
 		results: 3, when
 	})
 
-	t.equal(typeof model.earlierJourneysRef, 'string')
-	t.ok(model.earlierJourneysRef)
-	t.equal(typeof model.laterJourneysRef, 'string')
-	t.ok(model.laterJourneysRef)
+	t.equal(typeof model.earlierRef, 'string')
+	t.ok(model.earlierRef)
+	t.equal(typeof model.laterRef, 'string')
+	t.ok(model.laterRef)
 
 	let earliestDep = Infinity, latestDep = -Infinity
 	for (let j of model) {
@@ -294,7 +294,7 @@ test('earlier/later journeys, Salzburg Hbf -> Wien Westbahnhof', co(function* (t
 	const earlier = yield client.journeys(salzburgHbf, wienWestbahnhof, {
 		results: 3,
 		// todo: single journey ref?
-		beforeJourneys: model.earlierJourneysRef
+		beforeJourneys: model.earlierRef
 	})
 	for (let j of earlier) {
 		t.ok(new Date(j.departure) < earliestDep)
@@ -303,7 +303,7 @@ test('earlier/later journeys, Salzburg Hbf -> Wien Westbahnhof', co(function* (t
 	const later = yield client.journeys(salzburgHbf, wienWestbahnhof, {
 		results: 3,
 		// todo: single journey ref?
-		afterJourneys: model.laterJourneysRef
+		afterJourneys: model.laterRef
 	})
 	for (let j of later) {
 		t.ok(new Date(j.departure) > latestDep)

--- a/test/oebb.js
+++ b/test/oebb.js
@@ -110,9 +110,14 @@ const assertValidLine = (t, l) => { // with optional mode
 const test = tapePromise(tape)
 const client = createClient(oebbProfile)
 
+const salzburgHbf = '8100002'
+const wienWestbahnhof = '1291501'
+const wien = '1190100'
+const klagenfurtHbf = '8100085'
+const muenchenHbf = '8000261'
+const grazHbf = '8100173'
+
 test('Salzburg Hbf to Wien Westbahnhof', co(function* (t) {
-	const salzburgHbf = '8100002'
-	const wienWestbahnhof = '1291501'
 	const journeys = yield client.journeys(salzburgHbf, wienWestbahnhof, {
 		when, passedStations: true
 	})
@@ -178,7 +183,6 @@ test('Salzburg Hbf to Wien Westbahnhof', co(function* (t) {
 }))
 
 test('Salzburg Hbf to 1220 Wien, Wagramer Straße 5', co(function* (t) {
-	const salzburgHbf = '8100002'
 	const wagramerStr = {
 		type: 'location',
     	latitude: 48.236216,
@@ -223,7 +227,6 @@ test('Albertina to Salzburg Hbf', co(function* (t) {
     	name: 'Albertina',
     	id: '975900003'
 	}
-	const salzburgHbf = '8100002'
 	const journeys = yield client.journeys(albertina, salzburgHbf, {when})
 
 	t.ok(Array.isArray(journeys))
@@ -255,9 +258,6 @@ test('Albertina to Salzburg Hbf', co(function* (t) {
 }))
 
 test('Wien to Klagenfurt Hbf with stopover at Salzburg Hbf', co(function* (t) {
-	const wien = '1190100'
-	const klagenfurtHbf = '8100085'
-	const salzburgHbf = '8100002'
 	const [journey] = yield client.journeys(wien, klagenfurtHbf, {
 		via: salzburgHbf,
 		results: 1,
@@ -274,9 +274,45 @@ test('Wien to Klagenfurt Hbf with stopover at Salzburg Hbf', co(function* (t) {
 	t.end()
 }))
 
+test('earlier/later journeys, Salzburg Hbf -> Wien Westbahnhof', co(function* (t) {
+	const model = yield client.journeys(salzburgHbf, wienWestbahnhof, {
+		results: 3, when
+	})
+
+	t.equal(typeof model.earlierJourneysRef, 'string')
+	t.ok(model.earlierJourneysRef)
+	t.equal(typeof model.laterJourneysRef, 'string')
+	t.ok(model.laterJourneysRef)
+
+	let earliestDep = Infinity, latestDep = -Infinity
+	for (let j of model) {
+		const dep = +new Date(j.departure)
+		if (dep < earliestDep) earliestDep = dep
+		else if (dep > latestDep) latestDep = dep
+	}
+
+	const earlier = yield client.journeys(salzburgHbf, wienWestbahnhof, {
+		results: 3,
+		// todo: single journey ref?
+		beforeJourneys: model.earlierJourneysRef
+	})
+	for (let j of earlier) {
+		t.ok(new Date(j.departure) < earliestDep)
+	}
+
+	const later = yield client.journeys(salzburgHbf, wienWestbahnhof, {
+		results: 3,
+		// todo: single journey ref?
+		afterJourneys: model.laterJourneysRef
+	})
+	for (let j of later) {
+		t.ok(new Date(j.departure) > latestDep)
+	}
+
+	t.end()
+}))
+
 test('leg details for Wien Westbahnhof to München Hbf', co(function* (t) {
-	const wienWestbahnhof = '1291501'
-	const muenchenHbf = '8000261'
 	const journeys = yield client.journeys(wienWestbahnhof, muenchenHbf, {
 		results: 1, when
 	})
@@ -301,7 +337,6 @@ test('leg details for Wien Westbahnhof to München Hbf', co(function* (t) {
 }))
 
 test('departures at Salzburg Hbf', co(function* (t) {
-	const salzburgHbf = '8100002'
 	const deps = yield client.departures(salzburgHbf, {
 		duration: 5, when
 	})
@@ -365,7 +400,6 @@ test('locations named Salzburg', co(function* (t) {
 }))
 
 test('location', co(function* (t) {
-	const grazHbf = '8100173'
 	const loc = yield client.location(grazHbf)
 
 	assertValidStation(t, loc)

--- a/test/vbb.js
+++ b/test/vbb.js
@@ -173,10 +173,10 @@ test('earlier/later journeys', co(function* (t) {
 		results: 3, when
 	})
 
-	t.equal(typeof model.earlierJourneysRef, 'string')
-	t.ok(model.earlierJourneysRef)
-	t.equal(typeof model.laterJourneysRef, 'string')
-	t.ok(model.laterJourneysRef)
+	t.equal(typeof model.earlierRef, 'string')
+	t.ok(model.earlierRef)
+	t.equal(typeof model.laterRef, 'string')
+	t.ok(model.laterRef)
 
 	let earliestDep = Infinity, latestDep = -Infinity
 	for (let j of model) {
@@ -188,7 +188,7 @@ test('earlier/later journeys', co(function* (t) {
 	const earlier = yield client.journeys(spichernstr, bismarckstr, {
 		results: 3,
 		// todo: single journey ref?
-		beforeJourneys: model.earlierJourneysRef
+		beforeJourneys: model.earlierRef
 	})
 	for (let j of earlier) {
 		t.ok(new Date(j.departure) < earliestDep)
@@ -197,7 +197,7 @@ test('earlier/later journeys', co(function* (t) {
 	const later = yield client.journeys(spichernstr, bismarckstr, {
 		results: 3,
 		// todo: single journey ref?
-		afterJourneys: model.laterJourneysRef
+		afterJourneys: model.laterRef
 	})
 	for (let j of later) {
 		t.ok(new Date(j.departure) > latestDep)

--- a/test/vbb.js
+++ b/test/vbb.js
@@ -168,6 +168,44 @@ test('journeys – fails with no product', co(function* (t) {
 	}
 }))
 
+test('earlier/later journeys', co(function* (t) {
+	const model = yield client.journeys(spichernstr, bismarckstr, {
+		results: 3, when
+	})
+
+	t.equal(typeof model.earlierJourneysRef, 'string')
+	t.ok(model.earlierJourneysRef)
+	t.equal(typeof model.laterJourneysRef, 'string')
+	t.ok(model.laterJourneysRef)
+
+	let earliestDep = Infinity, latestDep = -Infinity
+	for (let j of model) {
+		const dep = +new Date(j.departure)
+		if (dep < earliestDep) earliestDep = dep
+		else if (dep > latestDep) latestDep = dep
+	}
+
+	const earlier = yield client.journeys(spichernstr, bismarckstr, {
+		results: 3,
+		// todo: single journey ref?
+		beforeJourneys: model.earlierJourneysRef
+	})
+	for (let j of earlier) {
+		t.ok(new Date(j.departure) < earliestDep)
+	}
+
+	const later = yield client.journeys(spichernstr, bismarckstr, {
+		results: 3,
+		// todo: single journey ref?
+		afterJourneys: model.laterJourneysRef
+	})
+	for (let j of later) {
+		t.ok(new Date(j.departure) > latestDep)
+	}
+
+	t.end()
+}))
+
 test('journey leg details', co(function* (t) {
 	const journeys = yield client.journeys(spichernstr, amrumerStr, {
 		results: 1, when

--- a/test/vbb.js
+++ b/test/vbb.js
@@ -178,6 +178,18 @@ test('earlier/later journeys', co(function* (t) {
 	t.equal(typeof model.laterRef, 'string')
 	t.ok(model.laterRef)
 
+	// when and earlierThan/laterThan should be mutually exclusive
+	t.throws(() => {
+		client.journeys(spichernstr, bismarckstr, {
+			when, earlierThan: model.earlierRef
+		})
+	})
+	t.throws(() => {
+		client.journeys(spichernstr, bismarckstr, {
+			when, laterThan: model.laterRef
+		})
+	})
+
 	let earliestDep = Infinity, latestDep = -Infinity
 	for (let j of model) {
 		const dep = +new Date(j.departure)
@@ -188,7 +200,7 @@ test('earlier/later journeys', co(function* (t) {
 	const earlier = yield client.journeys(spichernstr, bismarckstr, {
 		results: 3,
 		// todo: single journey ref?
-		beforeJourneys: model.earlierRef
+		earlierThan: model.earlierRef
 	})
 	for (let j of earlier) {
 		t.ok(new Date(j.departure) < earliestDep)
@@ -197,7 +209,7 @@ test('earlier/later journeys', co(function* (t) {
 	const later = yield client.journeys(spichernstr, bismarckstr, {
 		results: 3,
 		// todo: single journey ref?
-		afterJourneys: model.laterRef
+		laterThan: model.laterRef
 	})
 	for (let j of later) {
 		t.ok(new Date(j.departure) > latestDep)


### PR DESCRIPTION
closes #24